### PR TITLE
Allow changing the generated key_size

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,3 +26,5 @@ default['acme']['source_ips']  = ['66.133.109.36']
 default['acme']['private_key'] = nil
 default['acme']['gem_deps']    = true
 
+default['acme']['key_size']    = 2048
+

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -34,7 +34,7 @@ action :create do
     owner     new_resource.owner
     group     new_resource.group
     mode      00400
-    content   OpenSSL::PKey::RSA.new(2048).to_pem
+    content   OpenSSL::PKey::RSA.new(node['acme']['key_size']).to_pem
     sensitive true
     action    :nothing
   end.run_action(:create_if_missing)

--- a/providers/selfsigned.rb
+++ b/providers/selfsigned.rb
@@ -26,7 +26,7 @@ action :create do
     owner     new_resource.owner
     group     new_resource.group
     mode      00400
-    content   OpenSSL::PKey::RSA.new(2048).to_pem
+    content   OpenSSL::PKey::RSA.new(node['acme']['key_size']).to_pem
     sensitive true
     action    :create_if_missing
   end


### PR DESCRIPTION
Let's Encrypt supports 2048-bit and 4096-bit keys currently.