### PR TITLE
custom key size

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -31,6 +31,11 @@ platforms:
     run_command: /usr/lib/systemd/systemd
     provision_command:
       - /bin/yum install -y initscripts net-tools wget
+- name: ubuntu-14.04
+  driver_config:
+    image: ubuntu:14.04
+    disable_upstart: false
+    run_command: /sbin/init
 
 suites:
 - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,30 +24,35 @@ driver:
     memory: 1024
 
 platforms:
-- name: centos-7
-  driver:
-    box: centos/7 # virtualbox
-    image: centos-7-0-x64   # digitalocean
-- name: ubuntu-14.04
-  run_list:
-    - recipe[apt]
-  driver:
-    box: bento/ubuntu-14.04
-    image: ubuntu-14-04-x64
-
+  - name: centos-7
+    driver:
+      box: bento/centos-7.3 # virtualbox, vmware, parallels
+      image: centos-7-0-x64 # digitalocean
+  - name: ubuntu-14.04
+    run_list:
+      - recipe[apt]
+    driver:
+      box: bento/ubuntu-14.04
+      image: ubuntu-14-04-x64
+  - name: ubuntu-16.04
+    run_list:
+      - recipe[apt]
+    driver:
+      box: bento/ubuntu-16.04
+      image: ubuntu-16-04-x64
 
 provisioner:
   name: chef_zero
 
 suites:
-- name: default
-  run_list:
-  - recipe[acme_server]
-  - recipe[acme_client]
-  attributes:
-    boulder:
-      revision: 2d33a9900cafe82993744fe73bd341fe47df2171
-    acme:
-      endpoint: http://127.0.0.1:4000
-      contact:
-      - mailto:admin@example.com
+  - name: default
+    run_list:
+    - recipe[acme_server]
+    - recipe[acme_client]
+    attributes:
+      boulder:
+        revision: 2d33a9900cafe82993744fe73bd341fe47df2171
+      acme:
+        endpoint: http://127.0.0.1:4000
+        contact:
+        - mailto:admin@example.com

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Attributes
 * `node['acme']['renew']` - Days before the certificate expires at which the certificate will be renewed, default `30`.
 * `node['acme']['source_ips']` - IP addresses used by Let's Encrypt to verify the TLS certificates, it will change over time. This attribute is for firewall purposes. Allow these IPs for HTTP (tcp/80).
 * `node['acme']['private_key']` - Private key content of registered account.
+* `node['acme']['key_size']` - Default private key size used when resource property is not. Must be one out of: 2048, 3072, 4096. Defaults to 2048.
 
 Recipes
 -------
@@ -54,6 +55,7 @@ Providers
 | `alt_names`      | array   | []       | The common name for the certificate                    |
 | `crt`            | string  | nil      | File path to place the certificate                     |
 | `key`            | string  | nil      | File path to place the private key                     |
+| `key_size`       | integer | 2048     | Private key size. Must be one out of: 2048, 3072, 4096 |
 | `chain`          | string  | nil      | File path to place the certificate chain               |
 | `fullchain`      | string  | nil      | File path to place the certificate including the chain |
 | `owner`          | string  | root     | Owner of the created files                             |
@@ -70,6 +72,7 @@ Providers
 | `cn`             | string  | _name_   | The common name for the certificate                    |
 | `crt`            | string  | nil      | File path to place the certificate                     |
 | `key`            | string  | nil      | File path to place the private key                     |
+| `key_size`       | integer | 2048     | Private key size. Must be one out of: 2048, 3072, 4096 |
 | `chain`          | string  | nil      | File path to place the certificate chain               |
 | `owner`          | string  | root     | Owner of the created files                             |
 | `group`          | string  | root     | Group of the created files                             |
@@ -83,9 +86,9 @@ To generate a certificate for an apache2 website you can use code like this:
 include_recipe 'acme'
 
 # Set up contact information. Note the mailto: notation
-node.set['acme']['contact'] = ['mailto:me@example.com'] 
+node.set['acme']['contact'] = ['mailto:me@example.com']
 # Real certificates please...
-node.set['acme']['endpoint'] = 'https://acme-v01.api.letsencrypt.org' 
+node.set['acme']['endpoint'] = 'https://acme-v01.api.letsencrypt.org'
 
 site = "example.com"
 sans = ["www.#{site}"]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,4 +25,4 @@ default['acme']['source_ips']  = ['66.133.109.36']
 
 default['acme']['private_key'] = nil
 default['acme']['gem_deps']    = true
-
+default['acme']['key_size']    = 2048

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -34,7 +34,7 @@ action :create do
     owner     new_resource.owner
     group     new_resource.group
     mode      00400
-    content   OpenSSL::PKey::RSA.new(2048).to_pem
+    content   OpenSSL::PKey::RSA.new(new_resource.key_size).to_pem
     sensitive true
     action    :nothing
   end.run_action(:create_if_missing)

--- a/providers/selfsigned.rb
+++ b/providers/selfsigned.rb
@@ -26,7 +26,7 @@ action :create do
     owner     new_resource.owner
     group     new_resource.group
     mode      00400
-    content   OpenSSL::PKey::RSA.new(2048).to_pem
+    content   OpenSSL::PKey::RSA.new(new_resource.key_size).to_pem
     sensitive true
     action    :create_if_missing
   end

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -35,3 +35,8 @@ attribute :group,         :kind_of => String, :default => 'root'
 
 attribute :method,        :kind_of => String, :default => 'http'
 attribute :wwwroot,       :kind_of => String, :default => '/var/www'
+
+attribute :key_size,      :kind_of  => Integer,
+                          :default  => node['acme']['key_size'],
+                          :equal_to => [2048, 3072, 4096],
+                          :required => true

--- a/resources/selfsigned.rb
+++ b/resources/selfsigned.rb
@@ -30,3 +30,8 @@ attribute :chain,         :kind_of => String, :default => nil
 
 attribute :owner,         :kind_of => String, :default => 'root'
 attribute :group,         :kind_of => String, :default => 'root'
+
+attribute :key_size,      :kind_of  => Integer,
+                          :default  => node['acme']['key_size'],
+                          :equal_to => [2048, 3072, 4096],
+                          :required => true

--- a/test/fixtures/cookbooks/acme_client/recipes/default.rb
+++ b/test/fixtures/cookbooks/acme_client/recipes/default.rb
@@ -45,3 +45,11 @@ acme_certificate 'new.example.com' do
   method    'http'
   wwwroot   node['nginx']['default_root']
 end
+
+acme_certificate '4096.example.com' do
+  crt       '/etc/ssl/4096.example.com.crt'
+  key       '/etc/ssl/4096.example.com.key'
+  method    'http'
+  key_size  4096
+  wwwroot   node['nginx']['default_root']
+end

--- a/test/fixtures/cookbooks/acme_server/recipes/default.rb
+++ b/test/fixtures/cookbooks/acme_server/recipes/default.rb
@@ -25,12 +25,9 @@ file 'hosts' do
   only_if { platform? 'centos' }
 end
 
-chef_gem 'chef-rewind'
-require 'chef/rewind'
-
 include_recipe 'letsencrypt-boulder-server'
 
 # awaiting https://github.com/customink-webops/hostsfile/pull/78
-rewind hostsfile_entry: '127.0.0.1' do
+edit_resource(:hostsfile_entry, '127.0.0.1') do
   action :nothing
 end

--- a/test/integration/default/serverspec/certificate_spec.rb
+++ b/test/integration/default/serverspec/certificate_spec.rb
@@ -70,3 +70,13 @@ describe x509_private_key('/etc/ssl/new.example.com.key') do
   it { should_not be_encrypted }
   it { should have_matching_certificate('/etc/ssl/new.example.com.crt') }
 end
+
+describe x509_certificate('/etc/ssl/4096.example.com.crt') do
+  it { should be_certificate }
+  it { should have_purpose 'SSL server' }
+  it { should_not have_purpose 'SSL server CA' }
+  its(:keylength) { should be 4096 }
+  its(:validity_in_days) { should be > 30 }
+  its(:subject) { should match '/CN=4096.example.com/' }
+  its(:issuer) { should eq '/CN=happy hacker fake CA' }
+end


### PR DESCRIPTION
see #52

- introduces a global default attribute for key size which defaults to 2048
- allows setting a custom key size for each resource which overwrites the default
- minor tweaks to the test cookbook and test-kitchen setup to support all bento-supported virtualization providers.
