### PR TITLE
Add missing matchers

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -19,6 +19,9 @@
 #
 
 if defined?(ChefSpec)
+  ChefSpec.define_matcher(:acme_certificate)
+  ChefSpec.define_matcher(:acme_selfsigned)
+
   def create_acme_selfsigned(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:acme_selfsigned, :create, resource_name)
   end


### PR DESCRIPTION
It allows for testing notifications mentioned in [examples](https://github.com/Ragnarson/chef-acme#example). Like:

    it do
      expect(chef_run.acme_certificate("fauxhai.local")).
        to notify("service[nginx]").
        to(:restart)
    end