### PR TITLE
chef 13 compat. rename 'method' to 'validation_method' #62

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Use the `acme_certificate` provider to request a certificate. The webserver for 
 
 ```ruby
 acme_certificate 'test.example.com' do
-  crt      '/etc/ssl/test.example.com.crt'
-  key      '/etc/ssl/test.example.com.key'
-  method   'http'
-  wwwroot  '/var/www'
+  crt               '/etc/ssl/test.example.com.crt'
+  key               '/etc/ssl/test.example.com.key'
+  validation_method 'http'
+  wwwroot           '/var/www'
 end
 ```
 
@@ -49,22 +49,22 @@ A working example can be found in the included `acme_client` test cookbook.
 Providers
 ---------
 ### certificate
-| Property         | Type    | Default  | Description                                            |
-|  ---             |  ---    |  ---     |  ---                                                   |
-| `cn`             | string  | _name_   | The common name for the certificate                    |
-| `alt_names`      | array   | []       | The common name for the certificate                    |
-| `crt`            | string  | nil      | File path to place the certificate                     |
-| `key`            | string  | nil      | File path to place the private key                     |
-| `key_size`       | integer | 2048     | Private key size. Must be one out of: 2048, 3072, 4096 |
-| `chain`          | string  | nil      | File path to place the certificate chain               |
-| `fullchain`      | string  | nil      | File path to place the certificate including the chain |
-| `owner`          | string  | root     | Owner of the created files                             |
-| `group`          | string  | root     | Group of the created files                             |
-| `method`         | string  | http     | Validation method                                      |
-| `wwwroot`        | string  | /var/www | Path to the wwwroot of the domain                      |
-| `ignore_failure` | boolean | false    | Whether to continue chef run if issuance fails         |
-| `retries`        | integer | 0        | Number of times to catch exceptions and retry          |
-| `retry_delay`    | integer | 2        | Number of seconds to wait between retries              |
+| Property            | Type    | Default  | Description                                            |
+|  ---                |  ---    |  ---     |  ---                                                   |
+| `cn`                | string  | _name_   | The common name for the certificate                    |
+| `alt_names`         | array   | []       | The common name for the certificate                    |
+| `crt`               | string  | nil      | File path to place the certificate                     |
+| `key`               | string  | nil      | File path to place the private key                     |
+| `key_size`          | integer | 2048     | Private key size. Must be one out of: 2048, 3072, 4096 |
+| `chain`             | string  | nil      | File path to place the certificate chain               |
+| `fullchain`         | string  | nil      | File path to place the certificate including the chain |
+| `owner`             | string  | root     | Owner of the created files                             |
+| `group`             | string  | root     | Group of the created files                             |
+| `validation_method` | string  | http     | Validation method                                      |
+| `wwwroot`           | string  | /var/www | Path to the wwwroot of the domain                      |
+| `ignore_failure`    | boolean | false    | Whether to continue chef run if issuance fails         |
+| `retries`           | integer | 0        | Number of times to catch exceptions and retry          |
+| `retry_delay`       | integer | 2        | Number of seconds to wait between retries              |
 
 ### selfsigned
 | Property         | Type    | Default  | Description                                            |
@@ -107,11 +107,11 @@ end
 
 # Get and auto-renew the certificate from Let's Encrypt
 acme_certificate "#{site}" do
-  crt      "/etc/httpd/ssl/#{site}.crt"
-  key      "/etc/httpd/ssl/#{site}.key"
-  chain    "/etc/httpd/ssl/#{site}.pem"
-  method   "http"
-  wwwroot  "/var/www/#{site}/htdocs/"
+  crt               "/etc/httpd/ssl/#{site}.crt"
+  key               "/etc/httpd/ssl/#{site}.key"
+  chain             "/etc/httpd/ssl/#{site}.pem"
+  validation_method "http"
+  wwwroot           "/var/www/#{site}/htdocs/"
   notifies :restart, "service[apache2]"
   alt_names sans
 end

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -55,14 +55,14 @@ action :create do
 
       case authz.status
       when 'valid'
-        case new_resource.method
+        case new_resource.validation_method
         when 'http'
           authz.http01
         else
-          fail "[#{new_resource.cn}] Invalid validation method '#{new_resource.method}'"
+          fail "[#{new_resource.cn}] Invalid validation_method '#{new_resource.validation_method}'"
         end
       when 'pending'
-        case new_resource.method
+        case new_resource.validation_method
         when 'http'
           tokenpath = "#{new_resource.wwwroot}/#{authz.http01.filename}"
 
@@ -88,7 +88,7 @@ action :create do
           validation
 
         else
-          fail "[#{new_resource.cn}] Invalid validation method '#{new_resource.method}'"
+          fail "[#{new_resource.cn}] Invalid validation validation_method '#{new_resource.validation_method}'"
         end
       end
     end

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -21,22 +21,22 @@
 actions :create
 default_action :create
 
-attribute :cn,            :kind_of => String, :name_attribute => true
-attribute :alt_names,     :kind_of => Array,  :default => []
+attribute :cn,                :kind_of => String, :name_attribute => true
+attribute :alt_names,         :kind_of => Array,  :default => []
 
-attribute :crt,           :kind_of => String, :default => nil
-attribute :key,           :kind_of => String, :default => nil
+attribute :crt,               :kind_of => String, :default => nil
+attribute :key,               :kind_of => String, :default => nil
 
-attribute :chain,         :kind_of => String, :default => nil
-attribute :fullchain,     :kind_of => String, :default => nil
+attribute :chain,             :kind_of => String, :default => nil
+attribute :fullchain,         :kind_of => String, :default => nil
 
-attribute :owner,         :kind_of => String, :default => 'root'
-attribute :group,         :kind_of => String, :default => 'root'
+attribute :owner,             :kind_of => String, :default => 'root'
+attribute :group,             :kind_of => String, :default => 'root'
 
-attribute :method,        :kind_of => String, :default => 'http'
-attribute :wwwroot,       :kind_of => String, :default => '/var/www'
+attribute :validation_method, :kind_of => String, :default => 'http'
+attribute :wwwroot,           :kind_of => String, :default => '/var/www'
 
-attribute :key_size,      :kind_of  => Integer,
-                          :default  => node['acme']['key_size'],
-                          :equal_to => [2048, 3072, 4096],
-                          :required => true
+attribute :key_size,          :kind_of  => Integer,
+                               :default  => node['acme']['key_size'],
+                               :equal_to => [2048, 3072, 4096],
+                               :required => true

--- a/test/fixtures/cookbooks/acme_client/recipes/default.rb
+++ b/test/fixtures/cookbooks/acme_client/recipes/default.rb
@@ -30,26 +30,26 @@ include_recipe 'acme_client::nginx'
 
 # Request the real certificate
 acme_certificate 'test.example.com' do
-  alt_names ['web.example.com', 'mail.example.com']
-  fullchain '/etc/ssl/test.example.com.crt'
-  chain     '/etc/ssl/test.example.com-chain.crt'
-  key       '/etc/ssl/test.example.com.key'
-  method    'http'
-  wwwroot   node['nginx']['default_root']
-  notifies  :reload, 'service[nginx]'
+  alt_names         ['web.example.com', 'mail.example.com']
+  fullchain         '/etc/ssl/test.example.com.crt'
+  chain             '/etc/ssl/test.example.com-chain.crt'
+  key               '/etc/ssl/test.example.com.key'
+  validation_method 'http'
+  wwwroot           node['nginx']['default_root']
+  notifies          :reload, 'service[nginx]'
 end
 
 acme_certificate 'new.example.com' do
-  crt       '/etc/ssl/new.example.com.crt'
-  key       '/etc/ssl/new.example.com.key'
-  method    'http'
-  wwwroot   node['nginx']['default_root']
+  crt               '/etc/ssl/new.example.com.crt'
+  key               '/etc/ssl/new.example.com.key'
+  validation_method 'http'
+  wwwroot           node['nginx']['default_root']
 end
 
 acme_certificate '4096.example.com' do
-  crt       '/etc/ssl/4096.example.com.crt'
-  key       '/etc/ssl/4096.example.com.key'
-  method    'http'
-  key_size  4096
-  wwwroot   node['nginx']['default_root']
+  crt               '/etc/ssl/4096.example.com.crt'
+  key               '/etc/ssl/4096.example.com.key'
+  validation_method 'http'
+  key_size          4096
+  wwwroot           node['nginx']['default_root']
 end


### PR DESCRIPTION
This should fix #62 and the error:

```ruby
       <ArgumentError: Property `method` of resource `acme_certificate` overwrites an existing method.> with backtrace:
         # cookbooks/acme/resources/certificate.rb:36:in `class_from_file'
```

Please test