### PR TITLE
update license and various other metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,18 @@
 name             'acme'
 maintainer       'Thijs Houtenbos'
 maintainer_email 'thoutenbos@schubergphilis.com'
-license          'All rights reserved'
+license          'Apache-2.0'
 description      'ACME client cookbook for free and trusted SSL/TLS certificates from Let\'s Encrypt'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url       'https://github.com/schubergphilis/chef-acme' if respond_to?(:source_url)
 issues_url       'https://github.com/schubergphilis/chef-acme/issues' if respond_to?(:issues_url)
 version          '2.0.0'
+chef_version     '>= 12.1' if respond_to?(:chef_version)
+
+supports         'centos'
+supports         'debian'
+supports         'fedora'
+supports         'redhat'
+supports         'ubuntu'
+
+depends 'compat_resource'


### PR DESCRIPTION
LICENSE already says Apache 2.0 so it's probably just a leftover from the cookbook generator?