### PR TITLE
add compat_resource dependency to test cookbook, use latest version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -15,4 +15,4 @@ supports         'fedora'
 supports         'redhat'
 supports         'ubuntu'
 
-depends 'compat_resource'
+depends 'compat_resource', '>= 12.19'

--- a/test/fixtures/cookbooks/acme_server/metadata.rb
+++ b/test/fixtures/cookbooks/acme_server/metadata.rb
@@ -8,3 +8,4 @@ version          '0.1.0'
 
 depends          'rabbitmq', '= 4.10.0'
 depends          'letsencrypt-boulder-server'
+depends          'compat_resource', '>= 12.19'

--- a/test/fixtures/cookbooks/acme_server/recipes/default.rb
+++ b/test/fixtures/cookbooks/acme_server/recipes/default.rb
@@ -28,6 +28,7 @@ end
 include_recipe 'letsencrypt-boulder-server'
 
 # awaiting https://github.com/customink-webops/hostsfile/pull/78
+# edit_resource is a chef 12.10/compat_resource feature
 edit_resource(:hostsfile_entry, '127.0.0.1') do
   action :nothing
 end


### PR DESCRIPTION
This is related to your comment in #67 => edit_resource (the official sucessor to `chef-rewind`) depends on `compat_resource` as well.

I've also added the latest version as dependency, because it just backports features from core chef to older chef 12 versions (kind of run-time monkey-patching).

see also https://github.com/chef-cookbooks/compat_resource