### PR TITLE
Chef 13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Use the `acme_certificate` provider to request a certificate. The webserver for 
 ```ruby
 acme_certificate 'test.example.com' do
   crt               '/etc/ssl/test.example.com.crt'
+  chain             '/etc/ssl/test.example.com.pem'
   key               '/etc/ssl/test.example.com.key'
   validation_method 'http'
   wwwroot           '/var/www'
@@ -40,6 +41,7 @@ In case your webserver needs an already existing certificate when installing a n
 ```ruby
 acme_selfsigned 'test.example.com' do
   crt     '/etc/ssl/test.example.com.crt'
+  chain     '/etc/ssl/test.example.com.pem'
   key     '/etc/ssl/test.example.com.key'
 end
 ```
@@ -65,6 +67,8 @@ Providers
 | `ignore_failure`    | boolean | false    | Whether to continue chef run if issuance fails         |
 | `retries`           | integer | 0        | Number of times to catch exceptions and retry          |
 | `retry_delay`       | integer | 2        | Number of seconds to wait between retries              |
+
+By changes in Chef 13, the property in version 2.0.0 `method` in version 3.0.0 is called `validation_method`.
 
 ### selfsigned
 | Property         | Type    | Default  | Description                                            |

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'ACME client cookbook for free and trusted SSL/TLS certificates
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url       'https://github.com/schubergphilis/chef-acme' if respond_to?(:source_url)
 issues_url       'https://github.com/schubergphilis/chef-acme/issues' if respond_to?(:issues_url)
-version          '2.0.0'
+version          '3.0.0'
 chef_version     '>= 12.1' if respond_to?(:chef_version)
 
 supports         'centos'

--- a/test/fixtures/cookbooks/acme_client/recipes/default.rb
+++ b/test/fixtures/cookbooks/acme_client/recipes/default.rb
@@ -23,6 +23,7 @@ include_recipe 'acme'
 # Generate selfsigned certificate so nginx can start
 acme_selfsigned 'test.example.com' do
   crt     '/etc/ssl/test.example.com.crt'
+  chain   '/etc/ssl/test.example.com-chain.crt'
   key     '/etc/ssl/test.example.com.key'
 end
 
@@ -41,6 +42,7 @@ end
 
 acme_certificate 'new.example.com' do
   crt               '/etc/ssl/new.example.com.crt'
+  chain             '/etc/ssl/new.example.com-chain.crt'
   key               '/etc/ssl/new.example.com.key'
   validation_method 'http'
   wwwroot           node['nginx']['default_root']
@@ -48,6 +50,7 @@ end
 
 acme_certificate '4096.example.com' do
   crt               '/etc/ssl/4096.example.com.crt'
+  chain             '/etc/ssl/4096.example.com-chain.crt'
   key               '/etc/ssl/4096.example.com.key'
   validation_method 'http'
   key_size          4096

--- a/test/fixtures/cookbooks/acme_server/metadata.rb
+++ b/test/fixtures/cookbooks/acme_server/metadata.rb
@@ -6,6 +6,6 @@ description      'Installs/Configures the Boulder Acme server'
 long_description 'Installs/Configures the Boulder Acme server'
 version          '0.1.0'
 
-depends          'rabbitmq', '= 4.10.0'
+depends          'rabbitmq', '= 5.0.0'
 depends          'letsencrypt-boulder-server'
 depends          'compat_resource', '>= 12.19'


### PR DESCRIPTION
Enable acme cookbook to use in Chef 13.

Tested with `kitchen test centos-7` and running successfully.
:)