### PR TITLE
Chef 13 fix, hopefully everything

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -24,7 +24,6 @@ driver:
   privileged: true
 
 provisioner:
-  require_chef_omnibus: 12.17.44
 
 platforms:
 - name: centos-7

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -22,6 +22,8 @@ driver:
   name: docker
   use_sudo: false
   privileged: true
+  volume:
+    - /sys/fs/cgroup
 
 provisioner:
 
@@ -33,6 +35,7 @@ platforms:
     run_command: /usr/lib/systemd/systemd
     provision_command:
       - /bin/yum install -y initscripts net-tools wget
+
 - name: ubuntu-14.04
   driver_config:
     image: ubuntu:14.04

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -109,14 +109,16 @@ action :create do
               f.mode    00644
             end.run_action :create
 
-            Chef::Resource::File.new("#{new_resource.cn} SSL new chain", run_context).tap do |f|
-              f.path    new_resource.chain
-              f.owner   new_resource.owner
-              f.group   new_resource.group
-              f.content newcert.chain_to_pem
-              f.not_if  { new_resource.chain.nil? }
-              f.mode    00644
-            end.run_action :create
+            if new_resource.chain
+              Chef::Resource::File.new("#{new_resource.cn} SSL new chain", run_context).tap do |f|
+                f.path    new_resource.chain
+                f.owner   new_resource.owner
+                f.group   new_resource.group
+                f.content newcert.chain_to_pem
+                f.not_if  { new_resource.chain.nil? }
+                f.mode    00644
+              end.run_action :create
+            end
           end
         else
           fail "[#{new_resource.cn}] Validation failed, unable to request certificate"

--- a/providers/selfsigned.rb
+++ b/providers/selfsigned.rb
@@ -40,13 +40,14 @@ action :create do
     action  :create_if_missing
   end
 
+  return if new_resource.chain.nil?
+
   file "#{new_resource.cn} SSL selfsigned chain" do
     path    new_resource.chain
     owner   new_resource.owner
     group   new_resource.group
     mode    00644
     content lazy { self_signed_cert(new_resource.cn, OpenSSL::PKey::RSA.new(::File.read(new_resource.key))).to_pem }
-    not_if  { new_resource.chain.nil? }
     action  :create_if_missing
   end
 end

--- a/test/fixtures/cookbooks/acme_client/metadata.rb
+++ b/test/fixtures/cookbooks/acme_client/metadata.rb
@@ -7,4 +7,4 @@ long_description 'Configures the Acme cookbook'
 version          '0.1.0'
 
 depends          'acme'
-depends          'chef_nginx', '= 3.2.0'
+depends          'chef_nginx', '~> 6.0'

--- a/test/fixtures/cookbooks/acme_client/recipes/nginx.rb
+++ b/test/fixtures/cookbooks/acme_client/recipes/nginx.rb
@@ -36,5 +36,5 @@ cookbook_file "#{node['nginx']['default_root']}/index.html" do
 end
 
 nginx_site 'test' do
-  timing :immediately
+  notifies :reload, 'service[nginx]', :immediately
 end

--- a/test/fixtures/cookbooks/acme_server/metadata.rb
+++ b/test/fixtures/cookbooks/acme_server/metadata.rb
@@ -6,6 +6,6 @@ description      'Installs/Configures the Boulder Acme server'
 long_description 'Installs/Configures the Boulder Acme server'
 version          '0.1.0'
 
-depends          'rabbitmq', '= 4.10.0'
+depends          'rabbitmq', '~> 5.0'
 depends          'letsencrypt-boulder-server'
 depends          'compat_resource', '>= 12.19'


### PR DESCRIPTION
**rabbitmq / test-cookbook (1)**
okay, took me a while to fix that rabbitmq issue. turns out we and the rabbitmq-cookbook's CI haven't used the right docker setup for systemd (with mounted cgroup fs). RabbitMQ itself had a minor issue which covered that from me… anyway.

**providers:**  empy path throws an error, even when the not_if later stop the resource. On the long run we probably want to move provider+resource things together in the new chef 12.5+ custom resource layout (I've a demo in a local branch which needs to get rebased and cleaned up https://github.com/rmoriz/chef-acme/tree/rmoriz/working/resources)

**test-cookbook (2)**
I've bumped `chef_nginx` and fixed code which was removed when they switched from definitions (oldskool chef stuff) to a resource.

inspired by and obsoletes #70 