### PR TITLE
switch to dokken, add test matrix, add Ubuntu

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -19,38 +19,39 @@
 
 ---
 driver:
-  name: docker
-  use_sudo: false
-  privileged: true
-  volume:
-    - /sys/fs/cgroup
+  name: dokken
+  chef_version: latest
+  privileged: true # because Docker and systemd/Upstart
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup # because of systemd, rabbitmq
+
+transport:
+  name: dokken
 
 provisioner:
+  name: dokken
 
 platforms:
 - name: centos-7
-  driver_config:
+  driver:
     image: centos:7
     platform: rhel
-    run_command: /usr/lib/systemd/systemd
-    provision_command:
-      - /bin/yum install -y initscripts net-tools wget
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+      - RUN yum -y install lsof which systemd-sysv initscripts sudo
 
 - name: ubuntu-14.04
-  driver_config:
-    image: ubuntu:14.04
-    disable_upstart: false
-    run_command: /sbin/init
+  driver:
+    image: ubuntu-upstart:14.04
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN apt-get install -y sudo curl
 
-suites:
-- name: default
-  run_list:
-  - recipe[acme_server]
-  - recipe[acme_client]
-  attributes:
-    boulder:
-      revision: 2d33a9900cafe82993744fe73bd341fe47df2171
-    acme:
-      endpoint: http://127.0.0.1:4000
-      contact:
-      - mailto:admin@example.com
+- name: ubuntu-16.04
+  driver:
+    image: ubuntu:16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN apt-get install -y sudo curl

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,26 +23,32 @@ driver:
   customize:
     memory: 1024
 
+verifier:
+  root_path: '/opt/verifier'
+  sudo: false
+
+provisioner:
+  name: chef_zero
+
 platforms:
   - name: centos-7
     driver:
       box: bento/centos-7.3 # virtualbox, vmware, parallels
       image: centos-7-0-x64 # digitalocean
+
   - name: ubuntu-14.04
     run_list:
       - recipe[apt]
     driver:
       box: bento/ubuntu-14.04
       image: ubuntu-14-04-x64
+
   - name: ubuntu-16.04
     run_list:
       - recipe[apt]
     driver:
       box: bento/ubuntu-16.04
       image: ubuntu-16-04-x64
-
-provisioner:
-  name: chef_zero
 
 suites:
   - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,25 +17,38 @@
 # limitations under the License.
 #
 
+dist: trusty
 sudo: required
 services: docker
 addons:
   apt:
     sources:
-      - chef-stable-precise
+      - chef-stable-trusty
     packages:
       - chefdk
 
 cache:
   apt: true
 
+env:
+  matrix:
+    - INSTANCE=centos-7
+    - INSTANCE=ubuntu-1604
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: INSTANCE=ubuntu-1604
+
 before_install:
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
   - chef --version
   - docker --version
 
-install:
-  - chef exec bundle install --jobs=3 --retry=3 --without='doc integration_vagrant integration_cloud guard'
+# We are using ChefDK so no gem install required.
+# https://docs.travis-ci.com/user/customizing-the-build#Skipping-the-Installation-Step
+install: true
 
 script:
-  - travis_retry chef exec bundle exec rake integration[default-centos-7]
+  - KITCHEN_LOCAL_YAML=.kitchen.dokken.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
+  # TODO: add rubocop/cookstyle and foocritic checks

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :integration do
 end
 
 group :integration_docker do
-  gem 'kitchen-docker', '~> 2.1'
+  gem 'kitchen-dokken', '~> 1.1'
 end
 
 group :integration_vagrant do

--- a/Rakefile
+++ b/Rakefile
@@ -38,52 +38,23 @@ namespace :style do
   FoodCritic::Rake::LintTask.new(:chef)
 end
 
-desc 'Run Test Kitchen integration tests'
+desc 'Run all style checks'
+task :style => ['style:chef', 'style:ruby']
+
+# Integration tests. Kitchen.ci
 namespace :integration do
-  # Gets a collection of instances.
-  #
-  # @param regexp [String] regular expression to match against instance names.
-  # @param config [Hash] configuration values for the `Kitchen::Config` class.
-  # @return [Collection<Instance>] all instances.
-  def kitchen_instances(regexp, config)
-    instances = Kitchen::Config.new(config).instances
-    return instances if regexp.nil? || regexp == 'all'
-    instances.get_all(Regexp.new(regexp))
-  end
+  begin
+    require 'kitchen/rake_tasks'
 
-  # Runs a test kitchen action against some instances.
-  #
-  # @param action [String] kitchen action to run (defaults to `'test'`).
-  # @param regexp [String] regular expression to match against instance names.
-  # @param loader_config [Hash] loader configuration options.
-  # @return void
-  def run_kitchen(action, regexp, loader_config = {})
-    action = 'test' if action.nil?
-    require 'kitchen'
-    Kitchen.logger = Kitchen.default_file_logger
-    config = { loader: Kitchen::Loader::YAML.new(loader_config) }
-    kitchen_instances(regexp, config).each { |i| i.send(action) }
-  end
-
-  desc 'Run Test Kitchen integration tests using vagrant'
-  task :vagrant, [:regexp, :action] do |_t, args|
-    run_kitchen(args.action, args.regexp)
-  end
-
-  desc 'Run Test Kitchen integration tests using docker'
-  task :docker, [:regexp, :action] do |_t, args|
-    run_kitchen(args.action, args.regexp, local_config: '.kitchen.docker.yml')
-  end
-
-  desc 'Run Test Kitchen integration tests in the cloud'
-  task :cloud, [:regexp, :action] do |_t, args|
-    run_kitchen(args.action, args.regexp, local_config: '.kitchen.cloud.yml')
+    desc 'Run kitchen integration tests'
+    Kitchen::RakeTasks.new(:integratio)
+  rescue StandardError => e
+    puts ">>> Kitchen error: #{e}, omitting #{task.name}" unless ENV['CI']
   end
 end
 
-desc 'Run Test Kitchen integration tests'
-task :integration, [:regexp, :action] =>
-  ci? ? %w(integration:docker) : %w(integration:vagrant)
+desc 'Run all integration checks'
+task :integration => ['integration:kitchen:all']
 
 desc 'Run style and integration tests'
 task default: %w(style integration)


### PR DESCRIPTION
### switch from kitchen-docker to kitchen-dokken
  `kitchen-docker` is kind of legacy and Chef Software and others use`kitchen-dokken` for docker testing. As it's used by nearly all cookbooks in `https://github.com/chef-cookbooks` and part of ChefDK, it's probably save to say that this is the preferred solution of testing in containers at the moment.

  https://github.com/someara/kitchen-dokken

### Rakefile and kitchen cleanup
  Kitchen itself provides rake tasks for the build matrix and when executed with the `KITCHEN_LOCAL_YAML` variable set, it will merge the KITCHEN_LOCAL_YAML with the default `.kitchen.yml` file:

  ```shell
  kitchen verify centos # vagrant
  KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify centos # dokken 
  KITCHEN_LOCAL_YAML=.kitchen.digitalocean.yml kitchen converge ubuntu # digitalocean
  ```


### Adding Ubuntu 16.04
  Since I almost only use Ubuntu and Debian boxes, I thought adding the recent Ubuntu LTS release would be a good addition. Sadly it looks like the boulder-integration cookbook fails when it tries to connect to rabbitmq. So I've marked this case as "allow_failure" until it gets fixed.

