### PR TITLE
Update certificate when common name / alternate names change

### DIFF
--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -26,7 +26,7 @@ def names_changed?(cert, names)
   san_extension = cert.extensions.find { |e| e.oid == 'subjectAltName' }
   return false if san_extension.nil?
 
-  current = san_extension.value.split(', ').map { |v| v.split(':')[1] }
+  current = san_extension.value.split(', ').select { |v| v.start_with?('DNS:') }.map { |v| v.split(':')[1] }
   !(names - current).empty? || !(current - names).empty?
 end
 

--- a/test/fixtures/cookbooks/acme_client/recipes/http.rb
+++ b/test/fixtures/cookbooks/acme_client/recipes/http.rb
@@ -52,3 +52,20 @@ acme_certificate '4096.example.com' do
   key_size          4096
   wwwroot           node['nginx']['default_root']
 end
+
+acme_certificate 'web.example.com' do
+  fullchain         '/etc/ssl/web.example.com.crt'
+  chain             '/etc/ssl/web.example.com-chain.crt'
+  key               '/etc/ssl/web.example.com.key'
+  wwwroot           node['nginx']['default_root']
+  notifies          :reload, 'service[nginx]'
+end
+
+acme_certificate 'web.example.com' do
+  alt_names         ['mail.example.com']
+  fullchain         '/etc/ssl/web.example.com.crt'
+  chain             '/etc/ssl/web.example.com-chain.crt'
+  key               '/etc/ssl/web.example.com.key'
+  wwwroot           node['nginx']['default_root']
+  notifies          :reload, 'service[nginx]'
+end

--- a/test/integration/http/serverspec/certificate_spec.rb
+++ b/test/integration/http/serverspec/certificate_spec.rb
@@ -80,3 +80,8 @@ describe x509_certificate('/etc/ssl/4096.example.com.crt') do
   its(:subject) { should match '/CN=4096.example.com/' }
   its(:issuer) { should eq '/CN=happy hacker fake CA' }
 end
+
+describe command('openssl x509 -in /etc/ssl/web.example.com.crt -noout -text') do
+  its(:stdout) { should match(/DNS:web.example.com/) }
+  its(:stdout) { should match(/DNS:mail.example.com/) }
+end


### PR DESCRIPTION
This change makes it possible to update the certificate when the
common name changes or alternate names are added or removed.

Fixes #35