### PR TITLE
Remove unknown attribute validation 'min'

### DIFF
--- a/resources/ssl_certificate.rb
+++ b/resources/ssl_certificate.rb
@@ -32,7 +32,7 @@ attribute :key,                 :kind_of => String, :required => true
 attribute :owner,               :kind_of => String
 attribute :group,               :kind_of => String
 
-attribute :min_validity,        :kind_of => Integer, :min => 0
+attribute :min_validity,        :kind_of => Integer
 
 attribute :validation_method,   :kind_of => Symbol, :default => :tls_sni01
 


### PR DESCRIPTION
Hello, it causes an error when using the cookbook and does not look documented.
https://docs.chef.io/custom_resources.html#validators