### PR TITLE
Make sure nginx reloads

### DIFF
--- a/libraries/ssl_certificate/nginx.rb
+++ b/libraries/ssl_certificate/nginx.rb
@@ -61,6 +61,7 @@ class Chef
           end
 
           service 'nginx' do
+            supports status: true, restart: true, reload: true
             action :reload
           end
 
@@ -108,6 +109,7 @@ class Chef
           end
 
           service 'nginx' do
+            supports status: true, restart: true, reload: true
             action :reload
           end
 


### PR DESCRIPTION
According to docs chef silently does nothing when you are calling `action :reload` on a service which does not support it. No services support it by default, so you have to specify that by `supports reload: true` - https://docs.chef.io/resource_service.html#properties
This results in failing the `wait for nginx reload` step.
The same code is used here - https://github.com/chef-cookbooks/chef_nginx/blob/70dd9186bb3a2eadc36dc6d86c93732dfd3868b5/recipes/package.rb#L49
I wanted to write specs, but the dependencies seem to be broken.
