### PR TITLE
Switch to nginx cookbook for testing purposes

### DIFF
--- a/test/fixtures/cookbooks/acme_client/metadata.rb
+++ b/test/fixtures/cookbooks/acme_client/metadata.rb
@@ -7,4 +7,4 @@ long_description 'Configures the Acme cookbook'
 version          '0.1.0'
 
 depends          'acme'
-depends          'chef_nginx', '~> 6.0'
+depends          'nginx', '~> 8.1'

--- a/test/fixtures/cookbooks/acme_client/recipes/nginx.rb
+++ b/test/fixtures/cookbooks/acme_client/recipes/nginx.rb
@@ -18,8 +18,15 @@
 # limitations under the License.
 #
 
+# Work around an NGINX issue on CentOS
+# https://github.com/chef-cookbooks/nginx/issues/441
+yum_package 'openssl' do
+  action :upgrade
+  only_if { platform_family?('rhel') }
+end
+
 # Install a webserver
-include_recipe 'chef_nginx'
+include_recipe 'nginx'
 
 nginx_site 'test' do
   template 'nginx-test.conf'


### PR DESCRIPTION
1. Maintained & up-to-date
2. Functionally equivalent to chef_nginx
3. Needs a workaround for CentOS/RHEL systems

@thoutenbos, I _think_ this will fix the builds we found broken on #90. Works better on my system!