### PR TITLE
ACME v2 support

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -12,6 +12,10 @@ transport:
 provisioner:
   name: dokken
 
+verifier:
+  root_path: '/opt/verifier'
+  sudo: false
+
 platforms:
 - name: centos-7
   driver:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,9 +44,7 @@ suites:
     - recipe[acme_server]
     - recipe[acme_client::http]
   attributes:
-    boulder:
-      revision: 2d33a9900cafe82993744fe73bd341fe47df2171
     acme:
-      endpoint: http://127.0.0.1:4000
+      directory: https://127.0.0.1:14000/dir
       contact:
       - mailto:admin@example.com

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,8 +10,7 @@ verifier:
 
 provisioner:
   name: chef_zero
-  log_level: info
-  require_chef_omnibus: 12.19.36
+  always_update_cookbooks: true
 
 platforms:
   - name: centos-7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,7 @@ MethodLength:
   Enabled: false
 SignalException:
   Enabled: false
-TrailingCommaInLiteral:
+TrailingCommaInArrayLiteral:
   Enabled: false
 WordArray:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Starting with v4.0.0 of the acme cookbook the acme_ssl_certificate provider has 
 Attributes
 ----------
 
-| Attribute      | Description                                                                                                                                                              | Default                                  |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |  --------------------------------------: |
-| contact        | Contact information, default empty. Set to `mailto:your@email.com`                                                                                                       |  []                                      |
-| endpoint       | ACME server endpoint, Set to `https://acme-staging.api.letsencrypt.org` if you want to use the Let's Encrypt staging environment and corresponding certificates.         | `https://acme-v01.api.letsencrypt.org`   |
-| renew          | Days before the certificate expires at which the certificate will be renewed                                                                                             |  30                                      |
-| source_ips     | IP addresses used by Let's Encrypt to verify the TLS certificates, it will change over time. This attribute is for firewall purposes. Allow these IPs for HTTP (tcp/80). | ['66.133.109.36']                        |
-| private_key    | Private key content of registered account. Private keys identify the ACME client with the endpoint and are not transferable between staging and production endpoints.    | nil                                      |
-| key_size       | Default private key size used when resource property is not. Must be one out of: 2048, 3072, 4096.                                                                       | 2048                                     |
+| Attribute      | Description                                                                                                                                                                    | Default                                          |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------       | --------------------------------------:          |
+| contact        | Contact information, default empty. Set to `mailto:your@email.com`                                                                                                             | []                                               |
+| directory      | ACME server endpoint, Set to `https://acme-staging-v02.api.letsencrypt.org/directory` if you want to use the Let's Encrypt staging environment and corresponding certificates. | `https://acme-v02.api.letsencrypt.org/directory` |
+| renew          | Days before the certificate expires at which the certificate will be renewed                                                                                                   | 30                                               |
+| source_ips     | IP addresses used by Let's Encrypt to verify the TLS certificates, it will change over time. This attribute is for firewall purposes. Allow these IPs for HTTP (tcp/80).       | ['66.133.109.36']                                |
+| private_key    | Private key content of registered account. Private keys identify the ACME client with the endpoint and are not transferable between staging and production endpoints.          | nil                                              |
+| key_size       | Default private key size used when resource property is not. Must be one out of: 2048, 3072, 4096.                                                                             | 2048                                             |
 
 
 Recipes
@@ -36,7 +36,6 @@ Use the `acme_certificate` resource to request a certificate with the http-01 ch
 ```ruby
 acme_certificate 'test.example.com' do
   crt               '/etc/ssl/test.example.com.crt'
-  chain             '/etc/ssl/test.example.com-chain.crt'
   key               '/etc/ssl/test.example.com.key'
   wwwroot           '/var/www'
 end
@@ -65,8 +64,6 @@ Providers
 | `crt`               | string  | nil      | File path to place the certificate                     |
 | `key`               | string  | nil      | File path to place the private key                     |
 | `key_size`          | integer | 2048     | Private key size. Must be one out of: 2048, 3072, 4096 |
-| `chain`             | string  | nil      | File path to place the certificate chain               |
-| `fullchain`         | string  | nil      | File path to place the certificate including the chain |
 | `owner`             | string  | root     | Owner of the created files                             |
 | `group`             | string  | root     | Group of the created files                             |
 | `wwwroot`           | string  | /var/www | Path to the wwwroot of the domain                      |
@@ -119,7 +116,6 @@ end
 acme_certificate "#{site}" do
   crt               "/etc/httpd/ssl/#{site}.crt"
   key               "/etc/httpd/ssl/#{site}.key"
-  chain             "/etc/httpd/ssl/#{site}.pem"
   wwwroot           "/var/www/#{site}/htdocs/"
   notifies :restart, "service[apache2]"
   alt_names sans
@@ -128,7 +124,7 @@ end
 
 Testing
 -------
-The kitchen includes a `boulder` server to run the integration tests with, so testing can run locally without interaction with the online API's.
+The kitchen includes a `pebble` server to run the integration tests with, so testing can run locally without interaction with the online API's.
 
 Contributing
 ------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,10 +19,10 @@
 #
 
 default['acme']['contact']     = []
-default['acme']['endpoint']    = 'https://acme-v01.api.letsencrypt.org'
+default['acme']['directory']   = 'https://acme-v02.api.letsencrypt.org/directory'
 default['acme']['renew']       = 30
 default['acme']['source_ips']  = %w(66.133.109.36 64.78.149.164)
 
 default['acme']['private_key'] = nil
-default['acme']['gem_version'] = '0.6.2'
+default['acme']['gem_version'] = '2.0.1'
 default['acme']['key_size']    = 2048

--- a/libraries/acme.rb
+++ b/libraries/acme.rb
@@ -36,7 +36,7 @@ def acme_client
   @client = Acme::Client.new(private_key: private_key, directory: directory)
 
   if node['acme']['private_key'].nil?
-    registration = acme_client.new_account(contact: contact, terms_of_service_agreed: true)
+    acme_client.new_account(contact: contact, terms_of_service_agreed: true)
     node.normal['acme']['private_key'] = private_key.to_pem
   end
 

--- a/libraries/acme.rb
+++ b/libraries/acme.rb
@@ -29,64 +29,53 @@ def acme_client
 
   private_key = OpenSSL::PKey::RSA.new(node['acme']['private_key'].nil? ? 2048 : node['acme']['private_key'])
 
-  endpoint = new_resource.endpoint.nil? ? node['acme']['endpoint'] : new_resource.endpoint
+  directory = new_resource.directory.nil? ? node['acme']['directory'] : new_resource.directory
 
   contact = new_resource.contact.nil? ? node['acme']['contact'] : new_resource.contact
 
-  @client = Acme::Client.new(private_key: private_key, endpoint: endpoint)
+  @client = Acme::Client.new(private_key: private_key, directory: directory)
 
   if node['acme']['private_key'].nil?
-    registration = acme_client.register(contact: contact)
-    registration.agree_terms
+    registration = acme_client.new_account(contact: contact, terms_of_service_agreed: true)
     node.normal['acme']['private_key'] = private_key.to_pem
   end
 
   @client
 end
 
-def acme_authz_for(domain)
-  acme_client.authorize(domain: domain)
+def acme_order_certs_for(names)
+  acme_client.new_order(identifiers: names)
 end
 
 def acme_validate(authz)
-  authz.request_verification
+  authz.request_validation
 
   times = 60
 
   while times > 0
-    break unless authz.verify_status == 'pending'
+    break unless authz.status == 'pending'
     times -= 1
     sleep 1
+    authz.reload
   end
 
   authz
 end
 
-def acme_validate_immediately(authz, method, tokenroot, auth_file)
-  tokenroot.run_action(:create)
-  auth_file.run_action(:create)
-  validate = authz.send(method.to_sym)
-  validate.request_verification
-
-  times = 60
-
-  while times > 0
-    break unless validate.verify_status == 'pending'
-    times -= 1
-    sleep 1
-  end
-
-  validate
-end
-
-def acme_cert(cn, key, alt_names = [])
+def acme_cert(order, cn, key, alt_names = [])
   csr = Acme::Client::CertificateRequest.new(
     common_name: cn,
-    names: [cn, alt_names].flatten.compact,
+    names: alt_names,
     private_key: key
   )
+  order.finalize(csr: csr)
 
-  acme_client.new_certificate(csr)
+  while order.status == 'processing'
+    sleep 1
+    order.reload
+  end
+
+  order.certificate
 end
 
 def self_signed_cert(cn, alts, key)

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,8 +9,6 @@ issues_url       'https://github.com/schubergphilis/chef-acme/issues' if respond
 version          '4.0.0'
 chef_version     '>= 12.5' if respond_to?(:chef_version)
 
-depends 'compat_resource', '>= 12.19'
-
 %w(ubuntu debian redhat centos fedora).each do |os|
   supports os
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url       'https://github.com/schubergphilis/chef-acme' if respond_to?(:source_url)
 issues_url       'https://github.com/schubergphilis/chef-acme/issues' if respond_to?(:issues_url)
 version          '4.0.0'
-chef_version     '>= 12.5' if respond_to?(:chef_version)
+chef_version     '>= 13.9' if respond_to?(:chef_version)
 
 %w(ubuntu debian redhat centos fedora).each do |os|
   supports os

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -23,11 +23,8 @@ default_action :create
 property :cn,         String, name_property: true
 property :alt_names,  Array,  default: []
 
-property :crt,        [String, nil], default: nil
-property :key,        [String, nil], default: nil
-
-property :chain,      [String, nil], default: nil
-property :fullchain,  [String, nil], default: nil
+property :crt,        [String, nil], required: true
+property :key,        [String, nil], required: true
 
 property :owner,      String, default: 'root'
 property :group,      String, default: 'root'
@@ -36,7 +33,7 @@ property :wwwroot,    String, default: '/var/www'
 
 property :key_size,   Integer, default: node['acme']['key_size'], required: true, equal_to: [2048, 3072, 4096]
 
-property :endpoint,   [String, nil], default: nil
+property :directory,  [String, nil], default: nil
 property :contact,    Array, default: []
 
 def names_changed?(cert, names)
@@ -50,18 +47,6 @@ def names_changed?(cert, names)
 end
 
 action :create do
-  unless new_resource.crt.nil? ^ new_resource.fullchain.nil?
-    fail "[#{new_resource.cn}] No valid certificate output specified, only one of the crt/fullchain propery is permitted and required"
-  end
-
-  if new_resource.fullchain.nil? && new_resource.chain.nil?
-    fail "[#{new_resource.cn}] No valid chain output specified, a chain is required when outputting a cert"
-  end
-
-  if new_resource.key.nil?
-    fail "[#{new_resource.cn}] No valid key output specified, the key propery is required"
-  end
-
   file "#{new_resource.cn} SSL key" do
     path      new_resource.key
     owner     new_resource.owner
@@ -79,41 +64,33 @@ action :create do
 
   if !new_resource.crt.nil? && ::File.exist?(new_resource.crt)
     mycert   = ::OpenSSL::X509::Certificate.new ::File.read new_resource.crt
-  elsif !new_resource.fullchain.nil? && ::File.exist?(new_resource.fullchain)
-    mycert   = ::OpenSSL::X509::Certificate.new ::File.read new_resource.fullchain
   end
 
   if mycert.nil? || mycert.not_after <= renew_at || names_changed?(mycert, names)
-    all_validations = names.map do |domain|
-      authz = acme_authz_for domain
+    all_validations = []
+    order = acme_order_certs_for(names)
+    order.authorizations.each do |authorization|
+      authz = authorization.http
 
-      case authz.status
-      when 'valid'
-        authz.http01
-      when 'pending'
-        tokenpath = "#{new_resource.wwwroot}/#{authz.http01.filename}"
+      tokenpath = "#{new_resource.wwwroot}/#{authz.filename}"
 
-        tokenroot = directory ::File.dirname(tokenpath) do
-          owner     new_resource.owner
-          group     new_resource.group
-          mode      00755
-          recursive true
-        end
-
-        auth_file = file tokenpath do
-          owner   new_resource.owner
-          group   new_resource.group
-          mode    00644
-          content authz.http01.file_content
-        end
-        validation = acme_validate_immediately(authz, 'http01', tokenroot, auth_file)
-
-        if validation.status != 'valid'
-          fail "[#{new_resource.cn}] Validation failed for domain #{authz.domain}"
-        end
-
-        validation
+      tokenroot = directory ::File.dirname(tokenpath) do
+        owner     new_resource.owner
+        group     new_resource.group
+        mode      00755
+        recursive true
       end
+
+      auth_file = file tokenpath do
+        owner   new_resource.owner
+        group   new_resource.group
+        mode    00644
+        content authz.file_content
+      end
+
+      acme_validate(authz)
+
+      all_validations.push(authz)
     end
 
     ruby_block "create certificate for #{new_resource.cn}" do # ~FC014
@@ -123,28 +100,17 @@ action :create do
         end
 
         begin
-          newcert = acme_cert(new_resource.cn, mykey, new_resource.alt_names)
+          newcert = acme_cert(order, new_resource.cn, mykey, new_resource.alt_names)
         rescue Acme::Client::Error => e
           fail "[#{new_resource.cn}] Certificate request failed: #{e.message}"
         else
           Chef::Resource::File.new("#{new_resource.cn} SSL new crt", run_context).tap do |f|
-            f.path    new_resource.crt || new_resource.fullchain
+            f.path    new_resource.crt
             f.owner   new_resource.owner
             f.group   new_resource.group
-            f.content new_resource.crt.nil? ? newcert.fullchain_to_pem : newcert.to_pem
+            f.content newcert
             f.mode    00644
           end.run_action :create
-
-          if new_resource.chain
-            Chef::Resource::File.new("#{new_resource.cn} SSL new chain", run_context).tap do |f|
-              f.path    new_resource.chain
-              f.owner   new_resource.owner
-              f.group   new_resource.group
-              f.content newcert.chain_to_pem
-              f.not_if  { new_resource.chain.nil? }
-              f.mode    00644
-            end.run_action :create
-          end
         end
       end
     end

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -36,6 +36,11 @@ property :key_size,   Integer, default: node['acme']['key_size'], required: true
 property :directory,  [String, nil], default: nil
 property :contact,    Array, default: []
 
+property :chain, String, deprecated: 'The chain property has been deprecated as the acme-client gem now returns the full certificate chain by default (on the crt property.) Please update your cookbooks to remove this property.'
+property :fullchain, String, deprecated: 'The fullchain property has been deprecated as the acme-client gem now returns the full certificate chain by default (on the crt property.) Please update your cookbooks to remove this property.'
+
+deprecated_property_alias 'endpoint', 'directory', 'The endpoint property was renamed to directory, to reflect ACME v2 changes. Please update your cookbooks to use the new property name.'
+
 def names_changed?(cert, names)
   return false if names.empty?
 

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -63,7 +63,7 @@ action :create do
   renew_at = ::Time.now + 60 * 60 * 24 * node['acme']['renew']
 
   if !new_resource.crt.nil? && ::File.exist?(new_resource.crt)
-    mycert   = ::OpenSSL::X509::Certificate.new ::File.read new_resource.crt
+    mycert = ::OpenSSL::X509::Certificate.new ::File.read new_resource.crt
   end
 
   if mycert.nil? || mycert.not_after <= renew_at || names_changed?(mycert, names)

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -74,14 +74,14 @@ action :create do
 
       tokenpath = "#{new_resource.wwwroot}/#{authz.filename}"
 
-      tokenroot = directory ::File.dirname(tokenpath) do
+      directory ::File.dirname(tokenpath) do
         owner     new_resource.owner
         group     new_resource.group
         mode      00755
         recursive true
       end
 
-      auth_file = file tokenpath do
+      file tokenpath do
         owner   new_resource.owner
         group   new_resource.group
         mode    00644

--- a/test/fixtures/cookbooks/acme_client/recipes/http.rb
+++ b/test/fixtures/cookbooks/acme_client/recipes/http.rb
@@ -31,8 +31,7 @@ include_recipe 'acme_client::nginx'
 # Request the real certificate
 acme_certificate 'test.example.com' do
   alt_names         ['web.example.com', 'mail.example.com']
-  fullchain         '/etc/ssl/test.example.com.crt'
-  chain             '/etc/ssl/test.example.com-chain.crt'
+  crt               '/etc/ssl/test.example.com.crt'
   key               '/etc/ssl/test.example.com.key'
   wwwroot           node['nginx']['default_root']
   notifies          :reload, 'service[nginx]'
@@ -40,22 +39,19 @@ end
 
 acme_certificate 'new.example.com' do
   crt               '/etc/ssl/new.example.com.crt'
-  chain             '/etc/ssl/new.example.com-chain.crt'
   key               '/etc/ssl/new.example.com.key'
   wwwroot           node['nginx']['default_root']
 end
 
 acme_certificate '4096.example.com' do
   crt               '/etc/ssl/4096.example.com.crt'
-  chain             '/etc/ssl/4096.example.com-chain.crt'
   key               '/etc/ssl/4096.example.com.key'
   key_size          4096
   wwwroot           node['nginx']['default_root']
 end
 
 acme_certificate 'web.example.com' do
-  fullchain         '/etc/ssl/web.example.com.crt'
-  chain             '/etc/ssl/web.example.com-chain.crt'
+  crt               '/etc/ssl/web.example.com.crt'
   key               '/etc/ssl/web.example.com.key'
   wwwroot           node['nginx']['default_root']
   notifies          :reload, 'service[nginx]'
@@ -63,8 +59,7 @@ end
 
 acme_certificate 'web.example.com' do
   alt_names         ['mail.example.com']
-  fullchain         '/etc/ssl/web.example.com.crt'
-  chain             '/etc/ssl/web.example.com-chain.crt'
+  crt               '/etc/ssl/web.example.com.crt'
   key               '/etc/ssl/web.example.com.key'
   wwwroot           node['nginx']['default_root']
   notifies          :reload, 'service[nginx]'

--- a/test/fixtures/cookbooks/acme_server/attributes/default.rb
+++ b/test/fixtures/cookbooks/acme_server/attributes/default.rb
@@ -1,0 +1,3 @@
+default['go']['version'] = '1.11'
+
+default['pebble']['package'] = 'github.com/letsencrypt/pebble'

--- a/test/fixtures/cookbooks/acme_server/metadata.rb
+++ b/test/fixtures/cookbooks/acme_server/metadata.rb
@@ -6,6 +6,5 @@ description      'Installs/Configures the Boulder Acme server'
 long_description 'Installs/Configures the Boulder Acme server'
 version          '0.1.0'
 
-depends          'rabbitmq', '~> 5.0'
-depends          'letsencrypt-boulder-server'
-depends          'compat_resource', '>= 12.19'
+depends          'golang', '= 1.7.0'
+depends          'poise-service'

--- a/test/integration/http/serverspec/certificate_spec.rb
+++ b/test/integration/http/serverspec/certificate_spec.rb
@@ -27,22 +27,14 @@ describe x509_certificate('/etc/ssl/test.example.com.crt') do
   it { should_not have_purpose 'SSL server CA' }
   its(:keylength) { should be 2048 }
   its(:validity_in_days) { should be > 30 }
-  its(:subject) { should match '/CN=test.example.com/' }
-  its(:issuer) { should eq '/CN=happy hacker fake CA' }
+  its(:subject) { should match '/CN=test.example.com' }
+  its(:issuer) { should match '/CN=Pebble Intermediate CA' }
 end
 
 describe x509_private_key('/etc/ssl/test.example.com.key') do
   it { should be_valid }
   it { should_not be_encrypted }
   it { should have_matching_certificate('/etc/ssl/test.example.com.crt') }
-end
-
-describe x509_certificate('/etc/ssl/test.example.com-chain.crt') do
-  it { should be_certificate }
-  it { should have_purpose 'SSL server' }
-  it { should have_purpose 'SSL server CA' }
-  its(:subject) { should eq '/CN=happy hacker fake CA' }
-  its(:issuer) { should eq '/CN=cackling cryptographer fake ROOT' }
 end
 
 describe command('echo | openssl s_client -connect 0:443 2>&1 | openssl x509 -noout -serial') do
@@ -61,8 +53,8 @@ describe x509_certificate('/etc/ssl/new.example.com.crt') do
   it { should_not have_purpose 'SSL server CA' }
   its(:keylength) { should be 2048 }
   its(:validity_in_days) { should be > 30 }
-  its(:subject) { should match '/CN=new.example.com/' }
-  its(:issuer) { should eq '/CN=happy hacker fake CA' }
+  its(:subject) { should match '/CN=new.example.com' }
+  its(:issuer) { should match '/CN=Pebble Intermediate CA' }
 end
 
 describe x509_private_key('/etc/ssl/new.example.com.key') do
@@ -77,8 +69,8 @@ describe x509_certificate('/etc/ssl/4096.example.com.crt') do
   it { should_not have_purpose 'SSL server CA' }
   its(:keylength) { should be 4096 }
   its(:validity_in_days) { should be > 30 }
-  its(:subject) { should match '/CN=4096.example.com/' }
-  its(:issuer) { should eq '/CN=happy hacker fake CA' }
+  its(:subject) { should match '/CN=4096.example.com' }
+  its(:issuer) { should match '/CN=Pebble Intermediate CA' }
 end
 
 describe command('openssl x509 -in /etc/ssl/web.example.com.crt -noout -text') do


### PR DESCRIPTION
This implements ACME v2 support by upgrading the underlying acme-client gem to 2.0.1 and testing against https://github.com/letsencrypt/pebble . Please see the individual commits for further details.

Further testing against the real Let's Encrypt ACME v2 endpoint is needed, and this should be enough to get started with.