### PR TITLE
Clean up token files after use

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -95,6 +95,11 @@ action :create do
 
       acme_validate(authz)
 
+      file tokenpath do
+        backup false
+        action :delete
+      end
+
       all_validations.push(authz)
     end
 


### PR DESCRIPTION
The cookbook leaves behind validation token files which are redundant after validation is resolved (calling acme_validate).
In multi-project nodes, this consumes inodes and calls for hacky cleanup cronjobs.
I propose deleting the token file outright.