### PR TITLE
Fix tokens forming post-validation

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -84,14 +84,16 @@ action :create do
         group     new_resource.group
         mode      00755
         recursive true
-      end
+        action    :nothing
+      end.run_action(:create)
 
       file tokenpath do
         owner   new_resource.owner
         group   new_resource.group
         mode    00644
         content authz.file_content
-      end
+        action  :nothing
+      end.run_action(:create)
 
       acme_validate(authz)
 


### PR DESCRIPTION
Validation is happening in compile phase of the certificate resource.
However, the token file is forming in run-time phase, meaning the validation of each individual ACME order happens before the token file is created, making all validations fail.

There are two solutions to this:
1) Move the validation to run-time phase by placing the acme_validate call in a ruby_block resource
2) Move the token creation to compile phase by using the nothing-run_action idiom on its file and directory resource. This is implemented in the PR