### PR TITLE
bump acme-client gem to 2.0.3

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,5 +24,5 @@ default['acme']['renew']       = 30
 default['acme']['source_ips']  = %w(66.133.109.36 64.78.149.164)
 
 default['acme']['private_key'] = nil
-default['acme']['gem_version'] = '2.0.1'
+default['acme']['gem_version'] = '2.0.3'
 default['acme']['key_size']    = 2048


### PR DESCRIPTION
I had some nasty error with the 2.0.1 version and the current master branch of chef-acme (5bd8e5ccdc2b9aa3dfbecc0a96955756127abb5e): 

```
    ArgumentError
    -------------
    unknown keyword: directory
    
    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/acme/libraries/acme.rb:36:in `new'
    /var/chef/cache/cookbooks/acme/libraries/acme.rb:36:in `acme_client'
    /var/chef/cache/cookbooks/acme/libraries/acme.rb:47:in `acme_order_certs_for'
    /var/chef/cache/cookbooks/acme/resources/certificate.rb:76:in `block in class_from_file'
```