### PR TITLE
Marked fullchain as a deprecated_property_alias

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -37,7 +37,7 @@ property :dir,        [String, nil], default: nil
 property :contact,    Array, default: []
 
 property :chain, String, deprecated: 'The chain property has been deprecated as the acme-client gem now returns the full certificate chain by default (on the crt property.) Please update your cookbooks to remove this property.'
-property :fullchain, String, deprecated: 'The fullchain property has been deprecated as the acme-client gem now returns the full certificate chain by default (on the crt property.) Please update your cookbooks to remove this property.'
+deprecated_property_alias 'fullchain', 'crt', 'The fullchain property has been deprecated as the acme-client gem now returns the full certificate chain by default (on the crt property.) Please update your cookbooks to switch to \'crt\'.'
 
 deprecated_property_alias 'endpoint', 'dir', 'The endpoint property was renamed to dir, to reflect ACME v2 changes. Please update your cookbooks to use the new property name.'
 


### PR DESCRIPTION
Preferring to avoid immediate breakage for users, I recommend switching `fullchain` to an alias of `crt` as they effectively do the same things under ACMEv2.