### PR TITLE
Test fixes

### DIFF
--- a/test/fixtures/cookbooks/acme_client/recipes/nginx.rb
+++ b/test/fixtures/cookbooks/acme_client/recipes/nginx.rb
@@ -25,6 +25,11 @@ yum_package 'openssl' do
   only_if { platform_family?('rhel') }
 end
 
+if platform_family?('debian')
+  apt_update
+  apt_package 'apt-transport-https'
+end
+
 # Install a webserver
 include_recipe 'nginx'
 

--- a/test/fixtures/cookbooks/acme_server/recipes/default.rb
+++ b/test/fixtures/cookbooks/acme_server/recipes/default.rb
@@ -18,13 +18,15 @@
 # limitations under the License.
 #
 
+apt_update 'update' if platform_family?('debian')
+
 include_recipe 'golang::default'
 
 bash 'install pebble' do
   code <<-EOC
   source /etc/profile.d/golang.sh
   go get -u #{node['pebble']['package']}/...
-  cd $GOPATH/src/#{node['pebble']['package']} && go install ./...
+  cd $GOPATH/src/#{node['pebble']['package']} && git checkout v1.0.1 && go install ./...
   EOC
   creates "#{node['go']['gopath']}/src/#{node['pebble']['package']}"
 end


### PR DESCRIPTION
- Fix nginx setup in acme_client test cookbook (was looking to upgrade nginx cookbook dependency to v10 but there's a lot of breaking changes there, so work around for now.)
- Use Pebble v1.0.1 instead of master/v2.x (in a similar situation to the nginx cookbook above.)