### PR TITLE
Need lazy evaluation when using attributes in resources

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -31,7 +31,7 @@ property :group,      String, default: 'root'
 
 property :wwwroot,    String, default: '/var/www'
 
-property :key_size,   Integer, default: node['acme']['key_size'], required: true, equal_to: [2048, 3072, 4096]
+property :key_size,   Integer, default: lazy { node['acme']['key_size'] }, required: true, equal_to: [2048, 3072, 4096]
 
 property :dir,        [String, nil], default: nil
 property :contact,    Array, default: []

--- a/resources/selfsigned.rb
+++ b/resources/selfsigned.rb
@@ -31,7 +31,7 @@ property :chain,      [String, nil], default: nil
 property :owner,      String, default: 'root'
 property :group,      String, default: 'root'
 
-property :key_size,   Integer, default: node['acme']['key_size'], required: true, equal_to: [2048, 3072, 4096]
+property :key_size,   Integer, default: lazy { node['acme']['key_size'] }, required: true, equal_to: [2048, 3072, 4096]
 
 action :create do
   file "#{new_resource.cn} SSL selfsigned key" do


### PR DESCRIPTION
When using chef attributes as defaults in custom resources, you need lazy evaluation so attribute overrides, etc work correctly. See https://github.com/chef/chef/issues/6989