### PR TITLE
Update default.rb (Closes #120)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,5 +24,5 @@ default['acme']['renew']       = 30
 default['acme']['source_ips']  = %w(66.133.109.36 64.78.149.164)
 
 default['acme']['private_key'] = nil
-default['acme']['gem_version'] = '2.0.3'
+default['acme']['gem_version'] = '2.0.6'
 default['acme']['key_size']    = 2048


### PR DESCRIPTION
Upgrades acme-client version to 2.0.6 which supports faraday 1.0.0 which is required by chef.

Closes #120.