### PR TITLE
Adds a bit more information to authz failure

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -108,7 +108,13 @@ action :create do
     ruby_block "create certificate for #{new_resource.cn}" do # ~FC014
       block do
         unless (all_validations.map { |authz| authz.status == 'valid' }).all?
-          fail "[#{new_resource.cn}] Validation failed, unable to request certificate"
+          errors = all_validations.select do |authz|
+            authz.satus != 'valid'
+          end.map do |authz|
+            "{url: #{authz.url}, status: #{authz.status}, error: #{authz.error}} "
+          end.reduce(:+)
+
+          fail "[#{new_resource.cn}] Validation failed, unable to request certificate, Errors: [#{errors}]"
         end
 
         begin


### PR DESCRIPTION
# Problem
Currently, if a certificate request fails one of its authz, there is very little logging as to what caused it. In certificates with large numbers of alt_names, it is very difficult to diagnose which domain failed its http auth or figure out the specific reason as to why it failed, leading to a headache for dns admins using this on anything other than trivial instances.

# Fix
Adjust the block that triggers the fail so that it includes some additional information about what the failure is, and include it in the output of the chef run.