### PR TITLE
Fix 'satus' typo in cert creation ruby_block

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -109,7 +109,7 @@ action :create do
       block do
         unless (all_validations.map { |authz| authz.status == 'valid' }).all?
           errors = all_validations.select do |authz|
-            authz.satus != 'valid'
+            authz.status != 'valid'
           end.map do |authz|
             "{url: #{authz.url}, status: #{authz.status}, error: #{authz.error}} "
           end.reduce(:+)


### PR DESCRIPTION
In 4.1.2, certificate creation will fail due to a small typo in the `create certificate` block. Here's a fix.