### PR TITLE
Make private key file location configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ ACME Cookbook Changelog
 
 This file is used to list changes made in each version of the acme cookbook.
 
+Unreleased
+----------
+- twk3 - make private key file location configurable
+
 4.1.4
 ----------
 - detjensrobert - Chef 17 Compatibility

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,5 +24,6 @@ default['acme']['renew']       = 30
 default['acme']['source_ips']  = %w(66.133.109.36 64.78.149.164)
 
 default['acme']['private_key'] = nil
+default['acme']['private_key_file'] = '/etc/acme/account_private_key.pem'
 default['acme']['gem_version'] = '2.0.8'
 default['acme']['key_size']    = 2048

--- a/libraries/acme.rb
+++ b/libraries/acme.rb
@@ -28,7 +28,8 @@ def acme_client
   return @client if @client
 
   # load private_key from disk if present
-  node.default['acme']['private_key'] = ::File.read('/etc/acme/account_private_key.pem') if ::File.exist?('/etc/acme/account_private_key.pem')
+  private_key_file = node['acme']['private_key_file']
+  node.default['acme']['private_key'] = ::File.read(private_key_file) if ::File.exist?(private_key_file)
 
   private_key = OpenSSL::PKey::RSA.new(node['acme']['private_key'] || 2048)
 
@@ -43,8 +44,11 @@ def acme_client
     node.default['acme']['private_key'] = private_key.to_pem
 
     # write key to disk for persistence
-    directory '/etc/acme'
-    file '/etc/acme/account_private_key.pem' do
+    directory File.dirname(private_key_file) do
+      recursive true
+    end
+
+    file private_key_file do
       content private_key.to_pem
       mode '600'
       sensitive true


### PR DESCRIPTION
location can be configured via chef attributes

This is useful when using chef-acme in recipes that aren't managed by a chef server. (And we don't want to have our private key file match other chef-acme runs from other recipes).

This is the case for the GitLab omnibus package, where we would much rather install this to our own omnibus managed etc folder.
