### PR TITLE
Allow Integer for owner and group properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ ACME Cookbook Changelog
 
 This file is used to list changes made in each version of the acme cookbook.
 
+4.1.6
+----------
+- ramereth - Allow `Integer` for `owner` and `group` properties
+
 4.1.5
 ----------
 - twk3 - make private key file location configurable

--- a/README.md
+++ b/README.md
@@ -58,32 +58,32 @@ A working example can be found in the included `acme_client` test cookbook.
 Providers
 ---------
 ### certificate
-| Property            | Type    | Default  | Description                                            |
-|  ---                |  ---    |  ---     |  ---                                                   |
-| `cn`                | string  | _name_   | The common name for the certificate                    |
-| `alt_names`         | array   | []       | The common name for the certificate                    |
-| `crt`               | string  | nil      | File path to place the certificate                     |
-| `key`               | string  | nil      | File path to place the private key                     |
-| `key_size`          | integer | 2048     | Private key size. Must be one out of: 2048, 3072, 4096 |
-| `owner`             | string  | root     | Owner of the created files                             |
-| `group`             | string  | root     | Group of the created files                             |
-| `wwwroot`           | string  | /var/www | Path to the wwwroot of the domain                      |
-| `ignore_failure`    | boolean | false    | Whether to continue chef run if issuance fails         |
-| `retries`           | integer | 0        | Number of times to catch exceptions and retry          |
-| `retry_delay`       | integer | 2        | Number of seconds to wait between retries              |
-| `endpoint`          | string  | nil      | The Let's Encrypt endpoint to use                      |
-| `contact`           | array   | []       | The contact to use                                     |
+| Property            | Type           | Default  | Description                                            |
+|  ---                |  ---           |  ---     |  ---                                                   |
+| `cn`                | string         | _name_   | The common name for the certificate                    |
+| `alt_names`         | array          | []       | The common name for the certificate                    |
+| `crt`               | string         | nil      | File path to place the certificate                     |
+| `key`               | string         | nil      | File path to place the private key                     |
+| `key_size`          | integer        | 2048     | Private key size. Must be one out of: 2048, 3072, 4096 |
+| `owner`             | string,integer | root     | Owner of the created files                             |
+| `group`             | string,integer | root     | Group of the created files                             |
+| `wwwroot`           | string         | /var/www | Path to the wwwroot of the domain                      |
+| `ignore_failure`    | boolean        | false    | Whether to continue chef run if issuance fails         |
+| `retries`           | integer        | 0        | Number of times to catch exceptions and retry          |
+| `retry_delay`       | integer        | 2        | Number of seconds to wait between retries              |
+| `endpoint`          | string         | nil      | The Let's Encrypt endpoint to use                      |
+| `contact`           | array          | []       | The contact to use                                     |
 
 ### selfsigned
-| Property         | Type    | Default  | Description                                            |
-|  ---             |  ---    |  ---     |  ---                                                   |
-| `cn`             | string  | _name_   | The common name for the certificate                    |
-| `crt`            | string  | nil      | File path to place the certificate                     |
-| `key`            | string  | nil      | File path to place the private key                     |
-| `key_size`       | integer | 2048     | Private key size. Must be one out of: 2048, 3072, 4096 |
-| `chain`          | string  | nil      | File path to place the certificate chain               |
-| `owner`          | string  | root     | Owner of the created files                             |
-| `group`          | string  | root     | Group of the created files                             |
+| Property         | Type           | Default  | Description                                            |
+|  ---             |  ---           |  ---     |  ---                                                   |
+| `cn`             | string         | _name_   | The common name for the certificate                    |
+| `crt`            | string         | nil      | File path to place the certificate                     |
+| `key`            | string         | nil      | File path to place the private key                     |
+| `key_size`       | integer        | 2048     | Private key size. Must be one out of: 2048, 3072, 4096 |
+| `chain`          | string         | nil      | File path to place the certificate chain               |
+| `owner`          | string,integer | root     | Owner of the created files                             |
+| `group`          | string,integer | root     | Group of the created files                             |
 
 Example
 -------

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -28,8 +28,8 @@ property :alt_names,  Array,  default: []
 property :crt,        [String, nil], required: true
 property :key,        [String, nil], required: true
 
-property :owner,      String, default: 'root'
-property :group,      String, default: 'root'
+property :owner,      [String, Integer], default: 'root'
+property :group,      [String, Integer], default: 'root'
 
 property :wwwroot,    String, default: '/var/www'
 

--- a/resources/selfsigned.rb
+++ b/resources/selfsigned.rb
@@ -30,8 +30,8 @@ property :key,        [String, nil], required: true
 
 property :chain,      [String, nil]
 
-property :owner,      String, default: 'root'
-property :group,      String, default: 'root'
+property :owner,      [String, Integer], default: 'root'
+property :group,      [String, Integer], default: 'root'
 
 property :key_size,   Integer, default: lazy { node['acme']['key_size'] }, equal_to: [2048, 3072, 4096]
 


### PR DESCRIPTION
The upstream file resource supports using both String and Integer for owner/group properties. There are some use cases where setting the UID/GID is needed instead of the name (i.e. Docker volumes).

Signed-off-by: Lance Albertson <lance@osuosl.org>
