### PR TITLE
Make SAN entries support IP addresses

### DIFF
--- a/test/fixtures/cookbooks/acme_client/recipes/http.rb
+++ b/test/fixtures/cookbooks/acme_client/recipes/http.rb
@@ -57,3 +57,10 @@ acme_certificate 'web.example.com' do
   wwwroot           '/var/www/html'
   notifies          :reload, 'nginx_service[nginx]', :immediately
 end
+
+# Generate selfsigned certificate with both DNS and IP SANs for test
+acme_selfsigned 'ip.example.com' do
+  alt_names         ['ip.example.com', '192.168.18.17']
+  crt               '/etc/ssl/ip.example.com.crt'
+  key               '/etc/ssl/ip.example.com.key'
+end

--- a/test/integration/http/inspec/certificate_spec.rb
+++ b/test/integration/http/inspec/certificate_spec.rb
@@ -68,3 +68,8 @@ describe command('openssl x509 -in /etc/ssl/web.example.com.crt -noout -text') d
   its('stdout') { should match(/DNS:web.example.com/) }
   its('stdout') { should match(/DNS:mail.example.com/) }
 end
+
+describe command('openssl x509 -in /etc/ssl/ip.example.com.crt -noout -text') do
+  its('stdout') { should match(/DNS:ip.example.com/) }
+  its('stdout') { should match(/IP:192.168.18.17/) }
+end


### PR DESCRIPTION
If a self-signed address is an IP address, we should use the `IP:` prefix in the SAN fields instead of the `DNS:` prefix.