### PR TITLE
Fix IPv6 handling of IP addresses

### DIFF
--- a/libraries/acme.rb
+++ b/libraries/acme.rb
@@ -109,7 +109,7 @@ def valid_ip_address?(address)
   require 'ipaddr'
   begin
     ip = IPAddr.new(address)
-    ip.to_s == address || ip.to_s == address.downcase
+    true
   rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
     false
   end


### PR DESCRIPTION
Ruby normalizes IPv6 addresses:

```
ip = IPAddr.new('2001:0db8:85a3:0000:0000:8a2e:0370:7334')`
=> "2001:db8:85a3::8a2e:370:7334"
```

Simplify the IP address parsing to handle this.