### PR TITLE
Add EC Certificate Support to selfsigned Resource

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -19,12 +19,21 @@ platforms:
   - name: ubuntu-24.04
 
 suites:
-- name: http
-  run_list:
-    - recipe[acme_server]
-    - recipe[acme_client::http]
-  attributes:
-    acme:
-      dir: https://127.0.0.1:14000/dir
-      contact:
-        - mailto:admin@example.com
+  - name: http
+    run_list:
+      - recipe[acme_server]
+      - recipe[acme_client::http]
+    attributes:
+      acme:
+        dir: https://127.0.0.1:14000/dir
+        contact:
+          - mailto:admin@example.com
+  - name: selfsigned
+    run_list:
+      - recipe[acme_server]
+      - recipe[acme_client::selfsigned]
+    attributes:
+      acme:
+        dir: https://127.0.0.1:14000/dir
+        contact:
+          - mailto:admin@example.com

--- a/libraries/acme.rb
+++ b/libraries/acme.rb
@@ -144,7 +144,11 @@ def self_signed_cert(cn, alts, key)
   cert.subject = cert.issuer = OpenSSL::X509::Name.new([['CN', cn, OpenSSL::ASN1::UTF8STRING]])
   cert.not_before = Time.now
   cert.not_after = Time.now + 60 * 60 * 24 * node['acme']['renew']
-  cert.public_key = key.public_key
+  if key.is_a?(OpenSSL::PKey::EC)
+    cert.public_key = key
+  else
+    cert.public_key = key.public_key
+  end
   cert.serial = 0x0
   cert.version = 2
 

--- a/resources/selfsigned.rb
+++ b/resources/selfsigned.rb
@@ -34,6 +34,8 @@ property :owner,      [String, Integer], default: 'root'
 property :group,      [String, Integer], default: 'root'
 
 property :key_size,   Integer, default: lazy { node['acme']['key_size'] }, equal_to: [2048, 3072, 4096]
+property :key_type,   String, default: 'rsa', equal_to: %w(rsa ec)
+property :ec_curve,   String, default: lazy { node['acme']['ec_curve'] }, equal_to: %w(prime256v1 secp384r1 secp521r1)
 
 action :create do
   file "#{new_resource.cn} SSL selfsigned key" do
@@ -41,7 +43,12 @@ action :create do
     owner     new_resource.owner
     group     new_resource.group
     mode      '400'
-    content   OpenSSL::PKey::RSA.new(new_resource.key_size).to_pem
+    content   case new_resource.key_type
+              when 'rsa'
+                OpenSSL::PKey::RSA.new(new_resource.key_size).to_pem
+              when 'ec'
+                OpenSSL::PKey::EC.generate(new_resource.ec_curve).to_pem
+              end
     sensitive true
     action    :create_if_missing
   end
@@ -51,7 +58,7 @@ action :create do
     owner   new_resource.owner
     group   new_resource.group
     mode    '644'
-    content lazy { self_signed_cert(new_resource.cn, new_resource.alt_names, OpenSSL::PKey::RSA.new(::File.read(new_resource.key))).to_pem }
+    content lazy { self_signed_cert(new_resource.cn, new_resource.alt_names, OpenSSL::PKey.read(::File.read(new_resource.key))).to_pem }
     action  :create_if_missing
   end
 
@@ -60,7 +67,7 @@ action :create do
     owner   new_resource.owner
     group   new_resource.group
     mode    '644'
-    content lazy { self_signed_cert(new_resource.cn, new_resource.alt_names, OpenSSL::PKey::RSA.new(::File.read(new_resource.key))).to_pem }
+    content lazy { self_signed_cert(new_resource.cn, new_resource.alt_names, OpenSSL::PKey.read(::File.read(new_resource.key))).to_pem }
     not_if  { new_resource.chain.nil? }
     action  :create_if_missing
   end

--- a/test/fixtures/cookbooks/acme_client/recipes/selfsigned.rb
+++ b/test/fixtures/cookbooks/acme_client/recipes/selfsigned.rb
@@ -1,0 +1,24 @@
+acme_selfsigned 'selfsigned.example.com' do
+  crt     '/etc/ssl/selfsigned.example.com.crt'
+  key     '/etc/ssl/selfsigned.example.com.key'
+  alt_names ['www.selfsigned.example.com']
+end
+
+acme_selfsigned 'selfsigned-4096.example.com' do
+  crt       '/etc/ssl/selfsigned-4096.example.com.crt'
+  key       '/etc/ssl/selfsigned-4096.example.com.key'
+  key_size  4096
+end
+
+acme_selfsigned 'selfsigned-ec.example.com' do
+  crt       '/etc/ssl/selfsigned-ec.example.com.crt'
+  key       '/etc/ssl/selfsigned-ec.example.com.key'
+  key_type  'ec'
+end
+
+acme_selfsigned 'selfsigned-ec-secp521r1.example.com' do
+  crt       '/etc/ssl/selfsigned-ec-secp521r1.example.com.crt'
+  key       '/etc/ssl/selfsigned-ec-secp521r1.example.com.key'
+  key_type  'ec'
+  ec_curve  'secp521r1'
+end

--- a/test/integration/selfsigned/inspec/selfsigned_spec.rb
+++ b/test/integration/selfsigned/inspec/selfsigned_spec.rb
@@ -1,0 +1,30 @@
+describe x509_certificate('/etc/ssl/selfsigned.example.com.crt') do
+  it { should be_certificate }
+  its('key_length') { should be 2048 }
+  its('validity_in_days') { should be > 29 }
+  its('extensions.subjectAltName') { should include 'DNS:selfsigned.example.com' }
+  its('extensions.subjectAltName') { should include 'DNS:www.selfsigned.example.com' }
+  its('issuer.CN') { should match /selfsigned.example.com/ }
+end
+
+describe x509_certificate('/etc/ssl/selfsigned-4096.example.com.crt') do
+  it { should be_certificate }
+  its('key_length') { should be 4096 }
+  its('validity_in_days') { should be > 29 }
+  its('extensions.subjectAltName') { should include 'DNS:selfsigned-4096.example.com' }
+  its('issuer.CN') { should match /selfsigned-4096.example.com/ }
+end
+
+describe x509_certificate('/etc/ssl/selfsigned-ec.example.com.crt') do
+    it { should be_certificate }
+    its('validity_in_days') { should be > 29 }
+    its('extensions.subjectAltName') { should include 'DNS:selfsigned-ec.example.com' }
+    its('issuer.CN') { should match /selfsigned-ec.example.com/ }
+end
+
+describe x509_certificate('/etc/ssl/selfsigned-ec-secp521r1.example.com.crt') do
+    it { should be_certificate }
+    its('validity_in_days') { should be > 29 }
+    its('extensions.subjectAltName') { should include 'DNS:selfsigned-ec-secp521r1.example.com' }
+    its('issuer.CN') { should match /selfsigned-ec-secp521r1.example.com/ }
+end


### PR DESCRIPTION
### Summary of Changes

- Added EC certificate support to the selfsigned resource
- Added tests covering the entire selfsigned resource
- Made minor adjustments to self-signed certificate creation to account for OpenSSL API mismatches (see https://github.com/ruby/openssl/issues/29)